### PR TITLE
Remove email and sms templates from create_once_list

### DIFF
--- a/nexler/create_once_list.json
+++ b/nexler/create_once_list.json
@@ -1,6 +1,4 @@
 [
-  "app/templates/email",
-  "app/templates/sms",
   "app/kafkaActions",
   "app/kGateActions"
 ]


### PR DESCRIPTION
Removed email and sms templates from the list.